### PR TITLE
Update to reflect changes to nightly compiler

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,6 +75,7 @@ $(kernel): xargo $(rust_os) $(assembly_object_files) $(linker_script)
 	@$(ld) -n --gc-sections -T $(linker_script) -o $(kernel) \
 		$(assembly_object_files) $(rust_os)
 
+xargo: export RUST_TARGET_PATH=$(shell pwd)
 xargo:
 	@xargo build --target $(target)
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -103,7 +103,7 @@ pub extern "C" fn _Unwind_Resume() -> ! {
 
 #[lang = "eh_personality"]
 #[no_mangle]
-extern "C" fn eh_personality() {}
+pub extern "C" fn eh_personality() {}
 /// Runs during a `panic!()`
 #[no_mangle]
 #[lang = "panic_fmt"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,7 @@
 #![feature(associated_type_defaults)]
 #![feature(asm)]
 #![feature(abi_x86_interrupt)]
+#![feature(ptr_internals)]
 #![no_std]
 
 // crates.io crates
@@ -101,6 +102,7 @@ pub extern "C" fn _Unwind_Resume() -> ! {
 }
 
 #[lang = "eh_personality"]
+#[no_mangle]
 extern "C" fn eh_personality() {}
 /// Runs during a `panic!()`
 #[no_mangle]

--- a/x86_64-ESALP.json
+++ b/x86_64-ESALP.json
@@ -2,6 +2,7 @@
 	"llvm-target": "x86_64-unknown-none",
 	"target-endian": "little",
 	"target-pointer-width": "64",
+	"target-c-int-width": "32",
 	"linker-flavor": "gcc",
 	"os": "none",
 	"arch": "x86_64",


### PR DESCRIPTION
In addition to the changes in this commit, the shell line

    export RUST_TARGET_PATH=`pwd`

must be run in order for the OS to work. I am unsure of where (in the makefile) to put this. 