### PR TITLE
Add conditional to kernel remap

### DIFF
--- a/src/memory/paging/mapper.rs
+++ b/src/memory/paging/mapper.rs
@@ -101,6 +101,19 @@ impl Mapper {
         p1[page.p1_index()].set(frame, flags | PRESENT);
     }
 
+    /// Same as map_to, but fails silently if the page cannot be mapped
+    pub fn try_map_to<A>(&mut self, page: Page, frame: Frame, flags: EntryFlags, allocator: &mut A)
+        where A: FrameAllocate
+    {
+        let p3 = self.p4_mut().next_table_create(page.p4_index(), allocator);
+        let p2 = p3.next_table_create(page.p3_index(), allocator);
+        let p1 = p2.next_table_create(page.p2_index(), allocator);
+
+        if p1[page.p1_index()].is_unused() {
+            p1[page.p1_index()].set(frame, flags | PRESENT);
+        }
+    }
+
     /// Maps the page to some free frame with the provided flags.
     /// The free frame is allocated with the given allocator
     pub fn map<A>(&mut self, page: Page, flags: EntryFlags, allocator: &mut A)

--- a/src/memory/paging/mod.rs
+++ b/src/memory/paging/mod.rs
@@ -120,7 +120,7 @@ impl Page {
             ref mut frame_allocator,
             stack_allocator: _,
         } = lock.as_mut().unwrap();
-        active_table.map_to(self, frame, flags, frame_allocator);
+        active_table.map_to(self, frame, flags, frame_allocator).expect("Unable to map frame because page is already taken");
     }
 
     /// Map this `Page` to any availible `Frame`.
@@ -349,7 +349,7 @@ pub fn remap_the_kernel<FA>(active_table: &mut ActivePageTable,
 
             for frame in Frame::range_inclusive(start_frame, end_frame) {
                 let new_page = Page::containing_address(frame.start_address() + KERNEL_BASE);
-                mapper.map_to(new_page, frame, flags, &mut allocator);
+                mapper.map_to(new_page, frame, flags, &mut allocator).expect("Unable to map elf section frame");
             }
         }
 
@@ -365,7 +365,7 @@ pub fn remap_the_kernel<FA>(active_table: &mut ActivePageTable,
             let new_page = Page::containing_address(frame.start_address() + KERNEL_BASE);
             // if we have already mapped this page, it must have been
             // already mapped when we mapped the elf sections.
-            mapper.try_map_to(new_page, frame, PRESENT, &mut allocator);
+            let _ = mapper.map_to(new_page, frame, PRESENT, &mut allocator);
         }
     });
     let old_table = active_table.switch(new_table);

--- a/src/memory/paging/mod.rs
+++ b/src/memory/paging/mod.rs
@@ -363,7 +363,9 @@ pub fn remap_the_kernel<FA>(active_table: &mut ActivePageTable,
 
         for frame in Frame::range_inclusive(multiboot_start, multiboot_end) {
             let new_page = Page::containing_address(frame.start_address() + KERNEL_BASE);
-            mapper.map_to(new_page, frame, PRESENT, &mut allocator);
+            // if we have already mapped this page, it must have been
+            // already mapped when we mapped the elf sections.
+            mapper.try_map_to(new_page, frame, PRESENT, &mut allocator);
         }
     });
     let old_table = active_table.switch(new_table);

--- a/src/memory/paging/temporary_page.rs
+++ b/src/memory/paging/temporary_page.rs
@@ -40,10 +40,7 @@ impl TemporaryPage {
     pub fn map(&mut self, frame: Frame, active_table: &mut ActivePageTable) -> VirtualAddress {
         use super::entry::WRITABLE;
 
-        assert!(active_table.translate_page(self.page).is_none(),
-                "Temporary page is already mapped");
-
-        active_table.map_to(self.page, frame, WRITABLE, &mut self.allocator);
+        active_table.map_to(self.page, frame, WRITABLE, &mut self.allocator).expect("Temporary page is already mapped");
         self.page.start_address()
     }
 


### PR DESCRIPTION
Fix bug where the multiboot section ends
up on the same page as one of the elf
sections, thereby getting mapped twice by the
remap utility. The OS now silently does nothing
if it finds one of the pages it wants to map multiboot
to taken.